### PR TITLE
Change markdown files to create PDF using pandoc

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,9 @@
+# Swap files
+*.swp
+
+# Output formats
+*.pdf
+*.odt
+*.mobi
+*.epub
+

--- a/docs/01-Concepts.md
+++ b/docs/01-Concepts.md
@@ -106,7 +106,7 @@ examples at https://api.libreoffice.org/examples/examples.html (in the Java and
 Developer's Guide subdirectories). They can also be found in the Office download in
 <OFFICE>/sdk/examples; Basic, C++ and Python code is there as well. By the way,
 <OFFICE> is my way of writing the path to the LibreOffice directory, which for
-example is "C:\Program Files\LibreOffice 5" on my 32-bit test machine.
+example is `C:\Program Files\LibreOffice 5` on my 32-bit test machine.
 
 You should also browse the LibreOffice development forums
 (https://imaccanici.org/en.libreofficeforum.org) and the corresponding ones for
@@ -603,6 +603,6 @@ One of the aims of my utilities is to hide as much of the complexity of Office a
 Basic version of the API.
 
 Having just reread this section, I may have just convinced myself to become a Basic
-programmer . The reason I'm going to stick with Java is that it's a full-featured
+programmer. The reason I'm going to stick with Java is that it's a full-featured
 language, with massive numbers of standard and third-part APIs which can augment
 the Office API.

--- a/docs/03-Examining.md
+++ b/docs/03-Examining.md
@@ -43,7 +43,7 @@ online section is by typing:
 `loguide "Configuration Management"`
 
 Office stores a large assortment of XML configuration data as ".xcd" files in the
-<OFFICE>\share\registry directory. They can be programatically accessed in three
+`<OFFICE>\share\registry` directory. They can be programatically accessed in three
 steps: first a ConfigurationProvider service is created, which represents the
 configuration database tree. The tree is examined with a ConfigurationAccess service
 which is supplied with the path to the node of interest. Configuration properties can
@@ -85,8 +85,8 @@ System language location: ""
 ```
 
 Many other property names, which don't seem that useful, are documented in my Info
-class. One way of finding the most current list is to browse main.xcd in
-<OFFICE>\share\registry.
+class. One way of finding the most current list is to browse `main.xcd` in
+`<OFFICE>\share\registry`.
 
 
 ### 1.2.  Examining Path Settings

--- a/docs/10-Linguistics.md
+++ b/docs/10-Linguistics.md
@@ -352,7 +352,7 @@ Extensions:
 ```
 
 The "Loc" entries are the directories or OXT files containing the extensions. Most
-extensions are placed in the <OFFICE>\share\extensions\ folder on Windows.
+extensions are placed in the `<OFFICE>\share\extensions\` folder on Windows.
 
 Office can display similar information via its Tools, "Extension Manager" dialog, as
 in Figure 6.
@@ -828,7 +828,7 @@ https://extensions.libreoffice.org/extension-center?getCategories=Dictionary;
 many include a thesaurus with the dictionary.
 
 Thesaurus data is stored as ".idx" and ".dat" files in the same directory as the spell
-checker (i.e. in <OFFICE>\share\extensions\dict-en\), as can be seen in Figure 13.
+checker (i.e. in `<OFFICE>\share\extensions\dict-en\`), as can be seen in Figure 13.
 
 The files are built from WordNet data (https://wordnet.princeton.edu/), but use a text-
 based format explained very briefly in Daniel Naber's slides about the
@@ -847,7 +847,7 @@ nine for Java, listed at https://wordnet.princeton.edu/wordnet/related-projects/
 Office's default grammar checker (or proof reader) is Lightproof, a Python application
 developed by László Németh. Lightproof.py, and its support files, are installed in the
 same folder as the spell checker and thesaurus; on my machine that's
-<OFFICE>\share\extensions\dict-en\.
+`<OFFICE>\share\extensions\dict-en\`.
 
 Older versions of Lightproof are available from OpenOffice's extensions website at
 https://extensions.services.openoffice.org/project/lightproof. One reason for

--- a/docs/24-Complex_Data_Manipulation.md
+++ b/docs/24-Complex_Data_Manipulation.md
@@ -479,7 +479,7 @@ utilized. For example:
 // in CellTexts.java
      :
 // Insert two text paragraphs and a hyperlink into the cell
-XText xText = Lo.qi(XText.class, xCell);  // cell  text
+XText xText = Lo.qi(XText.class, xCell);  // cell -> text
 XTextCursor cursor = xText.createTextCursor();
 
 Write.appendPara(cursor, "Text in first line.");

--- a/docs/27-Funcs_Analysis.md
+++ b/docs/27-Funcs_Analysis.md
@@ -1425,7 +1425,7 @@ There are three constraint inequalities:
     ```java
     x <= 6
     y <= 8
-    z <= 4
+    z >= 4
     ```
 
 The 'profit' expression to be maximized is:

--- a/docs/27-Funcs_Analysis.md
+++ b/docs/27-Funcs_Analysis.md
@@ -924,7 +924,7 @@ x == 200000.0 when x*1.0*0.075  == 15000
 
 ## 4.  Linear and Nonlinear Solving
 
-Calc supports both linear and nonlinear programming via its Tools  Solver menu
+Calc supports both linear and nonlinear programming via its Tools > Solver menu
 item. The name "linear programming" dates from just after World War II, and doesn't
 mean programming in the modern sense; in fact, it's probably better to use its other
 common name, "linear optimization".
@@ -953,7 +953,7 @@ solvers) – two linear optimizers called "LibreOffice Linear Solver" and "Libre
 CoinMP Linear Solver", and two nonlinear ones called "DEPS Evolutionary
 Algorithm" and "SCO Evolutionary Algorithm". The easiest way of checking the
 current solver situation in your version of Office is to look at Calc's Solver dialog
-window (by clicking on the Tools  Solver menu item), and click on the "Options"
+window (by clicking on the Tools > Solver menu item), and click on the "Options"
 button. The options dialog window lists all the installed solvers, and their numerous
 parameters, as in Figure 8.
 
@@ -966,7 +966,7 @@ Figure 8. The LibreOffice Solvers and their Parameters.
 Another way of getting a list of the installed solvers, is to call Calc.listSolvers(),
 which is demonstrated in the first example given below.
 
-The two linear solvers are implemented as DLLs, located in the <OFFICE>\program
+The two linear solvers are implemented as DLLs, located in the `<OFFICE>\program`
 folder as lpsolve55.dll and CoinMP.dll. The source code for these libraries is online,
 at https://docs.libreoffice.org/sccomp/html/files.html, with the code (and graphs of the
 code) accessible via the "Files" tab. The file names are LpsolveSolver.cxx and
@@ -1001,7 +1001,7 @@ also a Wikipedia page about COIN-OR.
 The two nonlinear solvers are known as DEPS and SCO for short, and are explained
 in the OpenOffice wiki at https://wiki.openoffice.org/wiki/NLPSolver, along with
 descriptions of their extensive (and complicated) parameters. They're implemented as
-JAR files, located in <OFFICE>\share\extensions\nlpsolver as nlpsolver.jar and
+JAR files, located in `<OFFICE>\share\extensions\nlpsolver` as nlpsolver.jar and
 EvolutionarySolver.jar. Two of the examples below use these solvers.
 
 
@@ -1013,9 +1013,9 @@ https://lpsolve.sourceforge.net/5.1/formulate.htm. There are three constraint
 inequalities:
 
 ```
-120x + 210y ≤ 15000
-110x + 30y ≤ 4000
-x + y ≤ 75
+120x + 210y <= 15000
+110x + 30y <= 4000
+x + y <= 75
 ```
 The 'profit' expression to be maximized is:
 
@@ -1305,8 +1305,8 @@ This restricts the search for intersection points to the top-right quadrant of t
 Alternatively I could have implemented two more constraints:
 
 ```
-x ≥ 0
-y ≥ 0
+x >= 0
+y >= 0
 ```
 
 The solver's results are printed by Calc.solverReport():
@@ -1379,9 +1379,9 @@ to Calc's solvers.
 There are three constraint inequalities:
 
 ```java
-x ≤ 6
-y ≤ 8
-z ≥ 4
+x <= 6
+y <= 8
+z >= 4
 ```
 
 The 'profit' expression to be maximized is:
@@ -1498,18 +1498,18 @@ The problem comes from the Wikipedia page on nonlinear programming
 inequalities:
 
 ```
-x ≥ 0
-y ≥ 0
+x >= 0
+y >= 0
 x
 2
  + y
 2
- ≥ 1
+ >= 1
 x
 2
  + y
 2
- ≤ 2
+ <= 2
 ```
 
 The 'profit' expression to be maximized is:

--- a/docs/31-XY_Scatter_Charts.md
+++ b/docs/31-XY_Scatter_Charts.md
@@ -430,7 +430,7 @@ public static int getNumberFormatKey(XChartDocument chartDoc,
 
 The string-to-key conversion is straight forward if you know what number format
 string to use, but there's little documentation on them. Probably the best approach is to
-use the Format  Cells menu item in a spreadsheet document, and examine the
+use the Format > Cells menu item in a spreadsheet document, and examine the
 dialog in Figure 7.
 
 

--- a/docs/37-Driver_Manager.md
+++ b/docs/37-Driver_Manager.md
@@ -384,9 +384,9 @@ The documentation on how to use this driver is quite sparse and out of date. The
 protocol is given as "sdbc:ado:<ADO specific connection string>", with two
 examples:
 
-* sdbc:ado:PROVIDER=Microsoft.Jet.OLEDB.4.0;
-DATA SOURCE= c:\northwind.mdb
-* sdbc:ado:Provider=msdaora;data source=testdb
+* `sdbc:ado:PROVIDER=Microsoft.Jet.OLEDB.4.0;`
+`DATA SOURCE= c:\northwind.mdb`
+* `sdbc:ado:Provider=msdaora;data source=testdb`
 The first is the most relevant, but only supports the old Access file format (MDB). For
 ACCDB files (Access 2007 and later), it must be revised to:
 

--- a/docs/38-ODB_as_Zip.md
+++ b/docs/38-ODB_as_Zip.md
@@ -22,7 +22,7 @@ HSQLDB or Firebird database can be accessed through Java's JDBC without using
 the sdbc, sdbcx, or sdb modules in the Office API.
 
 The Office download includes a copy of the HSQLDB database engine (stored in
-<OFFICE DIR>\program\classes\hsqldb.jar) so there's no need to download any
+`<OFFICE DIR>\program\classes\hsqldb.jar`) so there's no need to download any
 software for manipulating HyperSQL databases through JDBC. However, Firebird
 programming requires Firebird's embedded engine and its JDBC driver, called
 Jaybird.
@@ -317,7 +317,7 @@ java -jar <OFFICE>\program\classes\hsqldb.jar --help
 ```
 
 Figure 4 shows the help generated when the JAR file is called inside the
-<OFFICE>\program\classes folder.
+`<OFFICE>\program\classes` folder.
 
 
 ![](images/38-ODB_as_Zip-4.png)
@@ -334,7 +334,7 @@ necessary JDBC driver.
 The easiest thing is to download the embedded version of Firebird from
 https://firebirdsql.org/en/downloads/, making sure to grab either the 32-bit or 64-
 bit version for your OS. This should be unzipped to a convenient location (e.g.
-d:\firebird), and the path added to Window's PATH environment variable.
+`d:\firebird`), and the path added to Window's PATH environment variable.
 
 
 !!! Bug
@@ -352,7 +352,7 @@ d:\firebird), and the path added to Window's PATH environment variable.
 
 The JDBC driver, called Jaybird, is a separate download from
 https://firebirdsql.org/en/jdbc-driver/. This should be unzipped to a convenient
-location (e.g. d:\jaybird).
+location (e.g. `d:\jaybird`).
 
 There's no need to add Jaybird to the classpath of the javac.exe compiler, but calls to
 java.exe must include the location of its JAR and associated DLL. For example,
@@ -401,7 +401,7 @@ isql.exe for that purpose, but it's not included in the embedded Firebird downlo
 The 'simplest' way of adding it is to download the zipped version of the full firebird
 system (called "Classic, Superclassic & Superserver"), and unzip only isql.exe which
 is in the bin/ directory. Copy isql.exe to the embedded firebird directory on your
-machine (e.g. into d:\firebird), and make a copy of the fbembed.dll file in that folder,
+machine (e.g. into `d:\firebird`), and make a copy of the fbembed.dll file in that folder,
 renaming it to fbclient.dll.
 
 The isql manual is online at https://firebirdsql.org/manual/isql.html. isql also has

--- a/docs/39-Forms_API_Overview.md
+++ b/docs/39-Forms_API_Overview.md
@@ -43,7 +43,7 @@ creating a text-based form, it's well worth reading the Base chapter because it 
 into detail about the General, Data, and Events tab in the properties dialog.
 
 A somewhat simpler example, which is purely text-based without data sources, can be
-found at https://openoffice.blogs.com/forms_fromscratch.pdf. I used this article (which
+found at <https://openoffice.blogs.com/forms_fromscratch.pdf>. I used this article (which
 is titled "Creating Forms from Scratch") to create the scratchExample.odt file used
 here.
 
@@ -146,7 +146,7 @@ over in Office's very large awt module, which implements its version of Java's A
 The names of the services start to become a little unclear at this point since the words
 "Control" and "Model" often appear together (e.g. in FormControlModel,
 UnoControlButtonModel, and UnoControlModel). My advice is to remember that
-"Model beats Control" . If a class name includes the word "Model", then it's
+"Model beats Control" :-). If a class name includes the word "Model", then it's
 probably for the model/data part of the control. If the name contains only "Control"
 then it's most likely for the rendering/appearance or listener part of the control.
 
@@ -165,11 +165,11 @@ surrounding form.
 
 The principal documentation on the forms API is chapter 13 of the Developer's Guide
 available as
-https://wiki.openoffice.org/w/images/d/d9/DevelopersGuide_OOo3.1.0.pdf.
+<https://wiki.openoffice.org/w/images/d/d9/DevelopersGuide_OOo3.1.0.pdf>.
 Alternatively, you can read the chapter online, starting at
-https://wiki.openoffice.org/wiki/Documentation/DevGuide/Forms/Forms (or use
+<https://wiki.openoffice.org/wiki/Documentation/DevGuide/Forms/Forms> (or use
 `loGuide Forms`). The guide's form examples are at
-https://api.libreoffice.org/examples/DevelopersGuide/examples.html#Forms.
+<https://api.libreoffice.org/examples/DevelopersGuide/examples.html#Forms>.
 
 
 ## 3.  Examining a Text-based Form

--- a/docs/41-Printing.md
+++ b/docs/41-Printing.md
@@ -1928,7 +1928,7 @@ Table 13. Windows 7's VBScript Printing Utilities.
 
 
 The utilities are Visual Basic scripts, located in the
-C:\Windows\System32\Printing_Admin_Scripts\en-US\ folder which isn't a standard
+`C:\Windows\System32\Printing_Admin_Scripts\en-US\` folder which isn't a standard
 part of Window's PATH environment variable.
 
 One way of finding documentation on these tools is by starting "Windows Help" and
@@ -2008,8 +2008,8 @@ An alternative is "printui" which starts Window's printui.dll
 However, I'd not recommend "print" or "printui" since Office is a much better
 command line printing tool.
 
-If you open a command prompt in the Office directory (e.g. in C:\Program
-Files\LibreOffice 5), you can get a list of its command line options by typing:
+If you open a command prompt in the Office directory (e.g. in `C:\Program
+Files\LibreOffice 5`), you can get a list of its command line options by typing:
 
 ```
 > soffice.exe –h

--- a/docs/42-Sending_E-mail.md
+++ b/docs/42-Sending_E-mail.md
@@ -205,14 +205,14 @@ creates a socket-based link to the specified mail server. If that link utilizes 
 successor TLS) for encrypted communication, then your code will probably crash
 with the error message "No SSL support included in this Python".
 
-This bug (https://bugs.documentfoundation.org/show_bug.cgi?id=77354) is marked
+This bug (<https://bugs.documentfoundation.org/show_bug.cgi?id=77354>) is marked
 as "RESOLVED NOTOURBUG" at Office's bugzilla website which seems a bit
 dismissive. The problem appears to be due to the position of Office's application
 folders in Window's PATH environment variable. When Windows searches for two
 DLLs, ssleay32.dll and libeay32.dll, which implement OpenSSL, it may find incorrect
 versions in folders mentioned earlier in PATH. It's these incorrect DLLs that cause
 Python to issue the cryptic error. One solution is to copy the correct DLLs from
-Office's "program\" folder into the "program\python-core-???\lib\" folder (??? is a
+Office's `program\` folder into the `program\python-core-???\lib\` folder (??? is a
 version number, such as 3.3.3), thereby ensuring they're chosen first.
 
 Another issue with switching to MailServiceProvider is that the programmer must
@@ -991,8 +991,8 @@ public static void mergeEmail(String dataSourceName,
 
 The e-mailing employs the same mailmerge.py Python script as MailServiceProvider,
 which means it will crash when using SSL encryption unless ssleay32.dll and
-libeay32.dll have been copied from Office's "program\" folder into "program\python-
-core-???\lib\". Please refer back to section 2 for more details.
+libeay32.dll have been copied from Office's `program\` folder into `program\python-
+core-???\lib\`. Please refer back to section 2 for more details.
 
 mailmerge.py attempts to open a link with the specified mail server at the given port,
 and usually has to supply a login and password to be allowed access. If you look back
@@ -1014,7 +1014,7 @@ button pressed. A second dialog opens, shown on the right in Figure 10, which le
 you enter a login and password for accessing the server. It's good practice not to enter
 a password since the data is stored as plain text in "registrymodifications.xcu" in
 Office's user configuration directory (often the folder
-$APPDATA$\LibreOffice\??\user). It's safer to pass the password to
+`$APPDATA$\LibreOffice\??\user`). It's safer to pass the password to
 Mail.mergeTask() at run time, as I've done in Mail.mergeEmail().
 
 mergeEmail() calls Mail.checkMailConfig() to check if the mail server address, port

--- a/docs/44-Office_as_GUI_Comp.md
+++ b/docs/44-Office_as_GUI_Comp.md
@@ -38,25 +38,25 @@ controlled and monitored by the program.
 The OOoBean class and its com.sun.star.comp.beans package aren't documented in
 LibreOffice, but there's an entire chapter about them in the Developer's Guide
 (chapter 16, "JavaBean for Office Components"), at
-https://wiki.openoffice.org/w/images/d/d9/DevelopersGuide_OOo3.1.0.pdf, and
-https://wiki.openoffice.org/wiki/Documentation/DevGuide/JavaBean/JavaBean_for_Office_Components
+<https://wiki.openoffice.org/w/images/d/d9/DevelopersGuide_OOo3.1.0.pdf>, and
+<https://wiki.openoffice.org/wiki/Documentation/DevGuide/JavaBean/JavaBean_for_Office_Components>
 (or use `loGuide JavaBean`). The chapter's example,
 OOoBeanViewer, wraps OOoBean in an old-style Applet (not a JApplet), and can be
 downloaded from
-https://api.libreoffice.org/examples/DevelopersGuide/examples.html#OfficeBean.
+<https://api.libreoffice.org/examples/DevelopersGuide/examples.html#OfficeBean>.
 
 Another source of information is the OOoBean code at
-https://github.com/LibreOffice/core/blob/master/bean/com/sun/star/comp/beans/OOoBean.java.
+<https://github.com/LibreOffice/core/blob/master/bean/com/sun/star/comp/beans/OOoBean.java>.
 It's also possible to decompile OOoBean 's JAR file, which you'll find in
-<Office>\program\classes\officebean.jar.
+`<Office>\program\classes\officebean.jar`.
 
 As you browse the documentation and source code, you may get the feeling that
 OOoBean has been abandoned. It's true that some functionality have been deprecated,
 but OOoBean still mostly works. Setting it up is tricky, requiring an undocumented
-UNO_PATH environment variable to be set when Office is invoked. Also, integrating
-OOoBean with Swing and my LibreOffice support classes required some work.
+`UNO_PATH` environment variable to be set when Office is invoked. Also, integrating
+`OOoBean` with Swing and my LibreOffice support classes required some work.
 
-OOoBean utilizes many parts of the Office API, since it starts Office, loads a
+`OOoBean` utilizes many parts of the Office API, since it starts Office, loads a
 document, and displays it on a Java Canvas. Some of that can be seen in Figure 1
 which gives a simplified view of its classes and interfaces.
 
@@ -96,7 +96,7 @@ better by the LayoutManager service explained later.
 
 There's a table of one-line descriptions of OOoBean's methods in chapter 16 of the
 Developer's Guide, and online at
-https://wiki.openoffice.org/wiki/Documentation/DevGuide/JavaBean/API_Overview
+<https://wiki.openoffice.org/wiki/Documentation/DevGuide/JavaBean/API_Overview>
 (or use `loGuide JavaBean "API Overview"`). I'll only explain the methods used in
 my OBeanPanel class.
 
@@ -796,7 +796,7 @@ menus) corresponds to its name in Office's GUI.
 
 Another approach is to search Office's source code – dispatches are defined inside
 ".xcu" files, and the UI related files are mostly in the subdirectory
-<OFFICE>\officecfg\registry\schema\org\openoffice\Office\UI.
+`<OFFICE>\officecfg\registry\schema\org\openoffice\Office\UI`.
 
 
 #### Listening to User Input and the Window

--- a/docs/45-UNO_Components.md
+++ b/docs/45-UNO_Components.md
@@ -54,7 +54,7 @@ service and interface with most of the necessary boilerplate API code. Other too
 mostly automate the creation of the component's extension file and its installation into
 Office.
 
-How this set of tools works together to form a code generation  compilation 
+How this set of tools works together to form a code generation -> compilation ->
 installation toolchain is somewhat confusing. Another problem is that some of the
 tools require changes to Window's PATH environment variable, and files and folders
 to be in specific locations. My solution to these issues is twelve (12!) batch files,
@@ -320,17 +320,17 @@ or use `loGuide "Type Mappings"`.
 ## 3.  Using idlc.bat
 
 My idlc.bat batch file utilizes idlc.exe, one of Office's SDK tools in
-<OFFICE>\sdk\bin\. Its main purpose is to generate type data, storing it in an URD
+`<OFFICE>\sdk\bin\`. Its main purpose is to generate type data, storing it in an URD
 file. A little more information can be found at
 https://api.libreoffice.org/docs/tools.html#idlc.
 
 Unfortunately,  idlc.exe can only process an IDL file if it's located in
-<OFFICE>\sdk\bin\, probably because its "-I" option can't find necessary support files
-when searching in other folders.  Also, the path to <OFFICE>\program\ must be
+`<OFFICE>\sdk\bin\`, probably because its "-I" option can't find necessary support files
+when searching in other folders.  Also, the path to `<OFFICE>\program\` must be
 added to Window's PATH environment variable so idlc.exe can employ DLLs stored
 there.
 
-The URD file is written to <OFFICE>\sdk\bin\, which is inconvenient, so idlc.bat
+The URD file is written to `<OFFICE>\sdk\bin\`, which is inconvenient, so idlc.bat
 moves the IDL and URD files back to the original directory.
 
 A typical call to idlc.bat uses the component's service name to identify the IDL file:
@@ -359,8 +359,8 @@ Tests\Component Tests\"
 
 The end result is the creation of a RandomSents.urd file.
 
-idlc.bat may fail because of its need to copy files into a folder beneath C:\Program
-Files\, which requires administrative privileges. The easiest workaround is to
+idlc.bat may fail because of its need to copy files into a folder beneath `C:\Program
+Files\`, which requires administrative privileges. The easiest workaround is to
 download the elevate.exe utility from https://code.kliu.org/misc/elevate/, which starts
 an administrative console so the necessary privileges are granted. The call to idlc.bat
 becomes:
@@ -382,7 +382,7 @@ descriptions in RDB (UCR stands for "Uno Core Reflection").
 The resulting RDB file can be printed using regview.exe.
 
 My regmerge.bat and regview.bat scripts call the corresponding UNO tools in
-<OFFICE>\program, and use the component's service name to identify the URD and
+`<OFFICE>\program`, and use the component's service name to identify the URD and
 RDB files. For example:
 
 ```
@@ -418,7 +418,7 @@ regview.bat.
 The RDB format was changed in LibreOffice 4.1, but most tools that use RDB can
 understand both the old and new formats. Unfortunately, regmerge.exe only generates
 old-style RDB, and regview cannot print the new format. That's means regview is
-useless for examining important registry databases in <OFFICE>\program, such as
+useless for examining important registry databases in `<OFFICE>\program`, such as
 types.rdb and services.rdb which use the new format.
 
 The API includes a com.sun.star.registry module with an XSimpleRegistry interface
@@ -433,7 +433,7 @@ readable).
 javamaker.exe (and cppumaker.exe) map IDL types to Java (and C++) using data
 from RDB files. RandomSents.rdb cannot be mapped on its own because it refers to
 types, such as XInterface, which it doesn't define. javamaker also needs Office's
-types.rdb, located in <OFFICE>\program.
+types.rdb, located in `<OFFICE>\program`.
 
 javamaker generates two things – a Java package representing the IDL module
 structure, and a Java ".class" file corresponding to the IDL interface.
@@ -528,10 +528,10 @@ few more times in the next two chapters since it can also generate code for add-
 and Calc add-ins.
 
 uno-skeletonmaker.exe suffers from the same constraints as idlc.exe – all its input
-data must be copied into its local directory (<OFFICE>\sdk\bin), and
-"<OFFICE>\program" must be added to Window's PATH environment variable so
-necessary DLLs can be located. As with idlc.exe, the copying of files into C:\Program
-Files\ requires administrative privileges, which may mean calling the batch file with
+data must be copied into its local directory (`<OFFICE>\sdk\bin`), and
+`<OFFICE>\program` must be added to Window's PATH environment variable so
+necessary DLLs can be located. As with idlc.exe, the copying of files into `C:\Program
+Files\` requires administrative privileges, which may mean calling the batch file with
 "elevate.exe".
 
 uno-skeletonmaker.exe requires a reference to the component's RDB file, Office's
@@ -621,7 +621,7 @@ getSentences().
 ## 7.  Compiling the Completed Implementation
 
 The completed RandomSentsImpl class is based on a Processing example at
-https://funprogramming.org/57-A-random-sentence-generator-writes-nonsense.html. I
+<https://funprogramming.org/57-A-random-sentence-generator-writes-nonsense.html>. I
 used that program's grammar and arrays of articles, adjectives, nouns, prepositions,
 and verbs.
 
@@ -916,7 +916,7 @@ by a Windows version of the UNIX zip tool downloaded from the Gow site
 ## 9.  Installing the Extension
 
 The Extension Manager can be started independently of Office by calling the unopkg
-tool in <OFFICE>\program with a "gui" argument; my extManager.bat script does
+tool in `<OFFICE>\program` with a "gui" argument; my extManager.bat script does
 this for you, resulting in a window something like Figure 7.
 
 
@@ -1010,12 +1010,12 @@ javac  -cp "%LO%\program\classes\*;."  %*
 ```
 
 The LO variable  is assigned the path to Office by code earlier in the script, and then
-javac looks in <Office>\program\classes for the JAR files that make up the API.
+javac looks in `<Office>\program\classes` for the JAR files that make up the API.
 
 This approach will not work when looking for the JAR that implements a new UNO
 component (e.g. RandomSentsImpl.jar in RandomSent.oxt). Extensions aren't stored
 with the API JARs, but usually in a folder below
-C:\Users\<USER_NAME>\AppData\Roaming\LibreOffice\. I say "usually" because
+`C:\Users\<USER_NAME>\AppData\Roaming\LibreOffice\`. I say "usually" because
 the location depends on the license details in the OXT description. The relevant field
 for RandomSent is:
 
@@ -1031,10 +1031,10 @@ for RandomSent is:
 ```
 
 The license will be accepted by a "user", which causes the extension to be installed in
-that user's AppData\Roaming\LibreOffice\ folder. Another licensing possibility is
+that user's `AppData\Roaming\LibreOffice\` folder. Another licensing possibility is
 "admin", which makes the extension available to everyone using Office on this
 machine. These are called shared mode extensions, and stored in
-<OFFICE>\share\extensions\.
+`<OFFICE>\share\extensions\`.
 
 In short then, how can javac.exe (and java.exe) find the JAR file for a new component
 when it comes time to compile (and run) a program such as PoemCreator.java?
@@ -1241,8 +1241,8 @@ Closing Office
 Office terminated
 
 Using RandomSents JAR:
-C:\Users\Ad\AppData\Roaming\LibreOffice\4\user\uno_packages\cache\uno
-_packages\lu29529rfgd.tmp_\RandomSents.oxt/RandomSentsImpl.jar
+`C:\Users\Ad\AppData\Roaming\LibreOffice\4\user\uno_packages\cache\uno
+_packages\lu29529rfgd.tmp_\RandomSents.oxt/RandomSentsImpl.jar`
 
 Compiling PoemCreator.java
            with LibreOffice SDK, JNA, Utils, and RandomSents...

--- a/docs/48-Event_Macros.md
+++ b/docs/48-Event_Macros.md
@@ -129,14 +129,14 @@ depending on if the macros are user or share, coded in Office Basic or another
 language, and on the version of Office and OS.
 
 The folders for share macros are probably the easiest to find – they're located inside
-<OFFICE>\share\ (e.g. C:\Program Files\LibreOffice 5\share\ on my machine). Basic
-macros are in share\basic\ while macros in other languages, such as Java, are in
-subfolders of share\Scripts\ (e.g. see Figure 3).
+`<OFFICE>\share\` (e.g. `C:\Program Files\LibreOffice 5\share\` on my machine). Basic
+macros are in `share\basic\` while macros in other languages, such as Java, are in
+subfolders of `share\Scripts\` (e.g. see Figure 3).
 
 
 ![](images/48-Event_Macros-3.png)
 
-Figure 3. The Non-Basic share\Scripts\ Macros Folders.
+Figure 3. The Non-Basic `share\Scripts\` Macros Folders.
 
 
 In other words, Java share macros will be in:
@@ -153,7 +153,7 @@ variable, which you can print out:
 echo %APPDATA%
 ```
 
-On my work test machine this prints "C:\Users\Ad\AppData\Roaming". You need to
+On my work test machine this prints `C:\Users\Ad\AppData\Roaming`. You need to
 locate the LibreOffice subdirectory in the Roaming\ folder and then its user\
 subdirectory, which will be inside LibreOffice\5\ or perhaps LibreOffice\4\. For
 instance, on one of my test machines the user\ folder is:
@@ -189,9 +189,9 @@ LANGPARAM identifies the macro's programming language, which may be "Basic",
 "BeanShell", "Java", "JavaScript", or "Python".
 
 LOCPARAM is the macro category, which for Java macros can be "user", "share", or
-"document". Extension macros use the label "user:uno_packages/" or
-"share:uno_packages/" followed by the name of the extension file (e.g.
-"user:uno_packages/FormMacros.oxt").
+"document". Extension macros use the label `user:uno_packages/` or
+`share:uno_packages/` followed by the name of the extension file (e.g.
+`user:uno_packages/FormMacros.oxt`).
 
 MACROPARAM takes the form:
 
@@ -381,39 +381,39 @@ Figure 4. The HelloWorld.printHW Macro.
 
 
 The four components of
-"HelloWorld.org.libreoffice.example.java_scripts.HelloWorld.printHW" are:
+`HelloWorld.org.libreoffice.example.java_scripts.HelloWorld.printHW` are:
 
 * folder: HelloWorld
-* package: org.libreoffice.example.java_scripts
-* class name: HelloWorld
-* function name: printHW
+* package: `org.libreoffice.example.java_scripts`
+* class name: `HelloWorld`
+* function name: `printHW`
 
-The HelloWorld\ folder is inside C:\Program Files\LibreOffice 5\share\Scripts\java\,
+The `HelloWorld\` folder is inside `C:\Program Files\LibreOffice 5\share\Scripts\java\`,
 as confirmed by Figure 5.
 
 
 ![](images/48-Event_Macros-5.png)
 
-Figure 5. The HelloWorld Folder in share\Scripts\java.
+Figure 5. The HelloWorld Folder in `share\Scripts\java`.
 
 
-Figure 5 also shows Highlight\, MemoryUsage\ and ShowEvent\ folders which hold
+Figure 5 also shows `Highlight\`, `MemoryUsage\` and `ShowEvent\` folders which hold
 the other three share macros listed by ListMacros.java.
 
-The HelloWorld\ folder contains the compiled HelloWorld class in a JAR file, and a
-parcel-descriptor.xml configuration file, which I'll explain later. It also has the source
+The `HelloWorld\` folder contains the compiled `HelloWorld` class in a JAR file, and a
+`parcel-descriptor.xml` configuration file, which I'll explain later. It also has the source
 code for HelloWorld, which isn’t required by Office, but included as an example for
-developers. Figure 6 shows the contents of HelloWorld\.
+developers. Figure 6 shows the contents of `HelloWorld\`.
 
 
 ![](images/48-Event_Macros-6.png)
 
-Figure 6. The Contents of the HelloWorld\ Folder.
+Figure 6. The Contents of the `HelloWorld\` Folder.
 
 
 The format of the HelloWorld class in the JAR file is:
 
-package org.libreoffice.example.java_scripts;
+`package org.libreoffice.example.java_scripts;`
 
 
 ```java
@@ -426,8 +426,8 @@ public class HelloWorld
 
 HelloWorld implements a single printHW() function.
 
-My FindMacros.java example calls Macros.findScripts() with a substring, and all the
-macro names containing that string are printed. For example, a search for "hello"
+My `FindMacros.java` example calls `Macros.findScripts()` with a substring, and all the
+macro names containing that string are printed. For example, a search for `hello`
 returns five matches:
 
 ```
@@ -658,7 +658,7 @@ Macros.execute("HelloWorld.org.libreoffice.example.
 ```
 
 This invokes the printHW() static method in the HelloWorld class in the
-org.libreoffice.example.java_scripts package shown back in Figure 4. The complete
+`org.libreoffice.example.java_scripts` package shown back in Figure 4. The complete
 code for the class (minus some comments) is:
 
 ```java
@@ -711,7 +711,7 @@ Figure 9. The LibreLogo Macro Module.
 Normally LibreLogo is accessed through its own View, Toolbars, Logo toolbar,
 which is just as well since the Macro selector doesn't list any macros in the LibreLogo
 module (see the empty area on the right of Figure 9). I had to examine the module's
-Python code in <OFFICE>\share\Scripts\python\LibreLogo\LibreLogo.py to work out
+Python code in `<OFFICE>\share\Scripts\python\LibreLogo\LibreLogo.py` to work out
 how to call it as a function.
 
 My UseLogo.java example creates a text document, writes the logo program text onto
@@ -951,8 +951,8 @@ jar cvf ShowEvent.jar ShowEvent.class
 ```
 
 The JAR is added to a new folder called ShowEvent\ beneath
-<OFFICE>\share\Scripts\java\, thereby making it a share macro. It's also necessary to
-include a parcel-descriptor.xml file:
+`<OFFICE>\share\Scripts\java\`, thereby making it a share macro. It's also necessary to
+include a `parcel-descriptor.xml` file:
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>

--- a/docs/49-Ext_Doc_Event_Macros.md
+++ b/docs/49-Ext_Doc_Event_Macros.md
@@ -33,7 +33,7 @@ manager does it for them. This section also uses more complex macros than the on
 in the previous chapter, namely ones that utilize their own dialogs and employ my
 utility classes.
 
-The FormMacros.oxt extension is created by zipping up a FormMacros\ folder, which
+The `FormMacros.oxt` extension is created by zipping up a `FormMacros\` folder, which
 is listed below:
 
 ```
@@ -57,8 +57,8 @@ FormMacros
          Utils.jar
 ```
 
-The macros are in the Utils\ folder, and are utilized by the form stored in
-FormMacrosTest.odt in the ways shown in Figure 1.
+The macros are in the `Utils\` folder, and are utilized by the form stored in
+`FormMacrosTest.odt` in the ways shown in Figure 1.
 
 
 ![](images/49-Ext_Doc_Event_Macros-1.png)
@@ -72,18 +72,18 @@ GetNumber.get macro is attached to the second textfield, and is activated when
 <RETURN> is pressed. A dialog, created by the macro, offers the user a choice of
 replacing the text by a number or clearing the textfield.
 
-To simplify the example a little, FormMacrosTest.odt was created by hand rather than
+To simplify the example a little, `FormMacrosTest.odt` was created by hand rather than
 programmatically. Also, I'm going to attach the extension's macros to the button and
 textfield using Office's GUI, as explained shortly.
 
-I won’t explain all the contents of the FormMacros\ folder, because most of them
+I won’t explain all the contents of the `FormMacros\` folder, because most of them
 were covered in early chapters, particularly in Chapter 45. For example, I won't be
 describing how I drew the "Number Extractor" dialog stored in
-dialogLibrary\NumExtractor.xdl since that technique was covered in the last chapter,
+`dialogLibrary\NumExtractor.xdl` since that technique was covered in the last chapter,
 in section 5.
 
-The new elements of FormMacros\ are the contents of manifest.xml and parcel-
-descriptor.xml.
+The new elements of `FormMacros\` are the contents of `manifest.xml` and `parcel-
+descriptor.xml`.
 
 manifest.xml states the location of the macros inside the extension, which in my case
 are in the Utils\ subdirectory. This is encoded as:
@@ -168,7 +168,7 @@ Instead I've stored the macros as .class files in Utils\. In addition, it's nece
 include "." in the classpath so NumActionListener.class can be found at runtime.
 
 The three Java files (GetText.java, GetNumber.java, and NumActionListener.java)
-are compiled and manually copied into FormMacros\Utils\. Then the
+are compiled and manually copied into `FormMacros\Utils\`. Then the
 installMacros.bat batch script zips up the folder as an OXT file, and calls unopkg.exe
 to install it. The extension manager displays the "Form Macros" as in Figure 2.
 
@@ -370,8 +370,8 @@ When the <RETURN> key is pressed, Forms.getControlModel() searches the form
 for the control that sent the event (i.e. the "AgeText" textfield).
 
 If the control is a textfield then the "Number Extractor" dialog is displayed in one of
-two ways – either loadXDLDialog() loads the dialog's XML from
-dialogLibrary\NumExtractor.xdl inside the extension, or runtimeDialog() creates the
+two ways – either `loadXDLDialog()` loads the dialog's XML from
+`dialogLibrary\NumExtractor.xdl` inside the extension, or runtimeDialog() creates the
 dialog dynamically by calling methods in my Dialogs utility class. I'll look at each
 approach in the next two sections.
 
@@ -806,7 +806,7 @@ I'll create a variation of the previous form, with the same functionality for it
 fields, but GetText.show and GetNumber.get (and its dialog and listener) will be
 stored inside the document.
 
-Office documents, such as FormMacrosTest.odt, can be manipulated as zip files; I
+Office documents, such as `FormMacrosTest.odt`, can be manipulated as zip files; I
 chose 7-Zip (https://7-zip.org/) for the purpose, because it's powerful, open
 source, and can be executed from the command line and from DOS batch scripts.
 
@@ -819,10 +819,10 @@ Figure 11.
 
 ![](images/49-Ext_Doc_Event_Macros-11.png)
 
-Figure 11. The Changed FormDocMacros_odt\ Folder
+Figure 11. The Changed `FormDocMacros_odt\` Folder
 
 The dialogLibrary\ folder contains the same "Number Extractor" dialog definition as
-before. The Scripts\java\Utils\ folder contains Macros.jar, and a new version of
+before. The `Scripts\java\Utils\` folder contains Macros.jar, and a new version of
 parcel-descriptor.xml.
 
 Macros.jar is different from the earlier extension, which used three classes
@@ -834,9 +834,11 @@ NumActionListener.class added to it.
 
 This change to the code organization is reflected in parcel-descriptor.xml. The
 classpath entries for the two macros become:
+```xml
 <prop name="classpath" value="Macros.jar"/>
-manifest.xml specifies the structure of FormDocMacros_odt\, so lines are added
-describing dialogLibrary\ and Scripts\:
+```
+manifest.xml specifies the structure of `FormDocMacros_odt\`, so lines are added
+describing `dialogLibrary\` and `Scripts\`:
 
 ```
 // added to manifest.xml

--- a/docs/50-Importing_XML.md
+++ b/docs/50-Importing_XML.md
@@ -288,7 +288,7 @@ The calls to infilter.bat and convert.bat rely on the user knowing a filter's na
 other filters in Office?
 
 A list of filters present in OpenOffice in 2007 can be found at
-https://wiki.openoffice.org/wiki/Framework/Article/Filter/FilterList_OOo_3_0.
+<https://wiki.openoffice.org/wiki/Framework/Article/Filter/FilterList_OOo_3_0>.
 However, a better approach is to call my FiltersInfo.java example which prints all the
 filters currently installed in Office, and some extra details about the "AbiWord",
 "Pay", and "Clubs" filters:
@@ -472,7 +472,7 @@ equivalent to Office's libxslt library. This means that I can use the "Pay" and 
 filters outside of Office by passing them to Java's Xalan processor.
 
 There's a lot of information about JAXP online, including in Oracle's tutorial at
-https://docs.oracle.com/javase/tutorial/jaxp/. Also "XSLT 2.0 and XPath 2.0
+<https://docs.oracle.com/javase/tutorial/jaxp/>. Also "XSLT 2.0 and XPath 2.0
 Programmer's Reference" by Michael Kay, which I mentioned earlier, includes an
 appendix on JAXP.
 
@@ -1568,7 +1568,7 @@ objects back into XML documents. I'm interested in the unmarshalling parts so da
 can be passed to Office as Java objects rather than as XML.
 
 Most of the magic of the XML-to-Java conversion is performed by Java's xjc.exe tool
-which comes as part of the JDK (you'll find it in %java_home%\bin\ on Windows).
+which comes as part of the JDK (you'll find it in `%java_home%\bin\` on Windows).
 xjc processes an XML schema (an XSD file)  rather than XML since the schema
 contains information about the XML's underlying structure.
 
@@ -1611,7 +1611,7 @@ The schema gives the names and types for each field in a payment object, and mak
 payments a sequence of payment objects.
 
 A good tutorial on XSD can be found at w3schools.com:
-https://w3schools.com/Xml/schema_intro.asp
+<https://w3schools.com/Xml/schema_intro.asp>
 
 If the resulting schema is stored in pay.xsd, then xjc generates Java classes like so:
 

--- a/docs/header.md
+++ b/docs/header.md
@@ -1,0 +1,10 @@
+---
+title: LibreOffice Programming
+author: Andrew Davison, flywire
+numbersections: true
+geometry: a4paper,left=2.54cm,right=2.54cm,top=2.54cm,bottom=3.67cm
+header-includes:
+ - \usepackage{fvextra}
+ - \DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,commandchars=\\\{\}}
+---
+\newpage

--- a/docs/header.md
+++ b/docs/header.md
@@ -1,6 +1,6 @@
 ---
 title: LibreOffice Programming
-author: Andrew Davison, flywire
+author: Andrew Davison, flywire, hosseinn
 numbersections: true
 geometry: a4paper,left=2.54cm,right=2.54cm,top=2.54cm,bottom=3.67cm
 header-includes:


### PR DESCRIPTION
Pandoc can now be used to create PDF out of the Markdown files

    pandoc --toc `cat toc.txt` -o inside-libreoffice.pdf

The toc.txt file should contain list of files in the correct order. A
rename that removes the space character in the file names can help to
simplify the pandoc invoke. This rename will be done later.